### PR TITLE
Deleted pprint from install requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="yahoo_finance_api2",
-    version="0.0.8",
+    version="0.0.9",
     author="Petr Kout",
     description="Yahooo Finance API package",
     long_description=long_description,
@@ -13,7 +13,6 @@ setuptools.setup(
     url="https://github.com/pkout/yahoo_finance_api2",
     packages=setuptools.find_packages(),
     install_requires=[
-      "pprint",
       "pyyaml",
       "requests"
     ],


### PR DESCRIPTION
pprint is now part of the standard library and therefore should not to be installed separately. Furthermore since last week it CAN NOT be installed any longer via pip/pypi (https://pypi.org/project/pprint/). This gives in error when installing yahoo_finance_api2.